### PR TITLE
修复部分参数说明无法正确显示的问题

### DIFF
--- a/ui/novel_params_tab.py
+++ b/ui/novel_params_tab.py
@@ -3,6 +3,7 @@
 import customtkinter as ctk
 from tkinter import filedialog, messagebox
 from ui.context_menu import TextWidgetContextMenu
+from tooltips import tooltips
 
 def build_novel_params_area(self, start_row=1):
     self.params_frame = ctk.CTkScrollableFrame(self.right_frame, orientation="vertical")
@@ -105,6 +106,6 @@ def create_label_with_help_for_novel_params(self, parent, label_text, tooltip_ke
     label = ctk.CTkLabel(frame, text=label_text, font=font)
     label.pack(side="left")
     btn = ctk.CTkButton(frame, text="?", width=22, height=22, font=("Microsoft YaHei", 10),
-                        command=lambda: messagebox.showinfo("参数说明", "暂无说明"))
+                        command=lambda: messagebox.showinfo("参数说明", tooltips.get(tooltip_key, "暂无说明")))
     btn.pack(side="left", padx=3)
     return frame


### PR DESCRIPTION
虽然`tooltips.py`里已有对各项参数的说明，但因为`novel_params_tab.py`中并未正确引入`tooltips`，因此部分参数说明无法正确显示。此项提交修复了这个问题。

![tooltips](https://github.com/user-attachments/assets/4aae5457-540a-42d3-8875-3ad91cf4d265)
