### PR TITLE
fix: update google-auth version constraint to resolve dependency conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ frozenlist==1.7.0
 fsspec==2025.9.0
 google-api-core==2.25.1
 google-api-python-client==2.181.0
-google-auth==2.40.3
+google-auth>=2.48.1
 google-auth-httplib2==0.2.0
 google-genai==1.73.1
 googleapis-common-protos==1.70.0


### PR DESCRIPTION
## Summary

- Updated `google-auth` version constraint in `requirements.txt` from `==2.40.3` to `>=2.48.1`

## Problem

`google-genai==1.73.1` requires `google-auth>=2.48.1`, but `requirements.txt` pinned `google-auth==2.40.3`. This caused `pip install -r requirements.txt` to fail with a dependency resolution conflict.

## Fix

Relaxed the `google-auth` version constraint to `>=2.48.1` so pip can resolve a compatible version that satisfies all packages (`google-api-core`, `google-api-python-client`, `google-auth-httplib2`, and `google-genai`).

## Test plan

- [ ] `pip install -r requirements.txt` completes without dependency conflicts