### PR TITLE
[codex] fix: remove think tags from LLM output

### DIFF
--- a/novel_generator/common.py
+++ b/novel_generator/common.py
@@ -68,7 +68,7 @@ def invoke_with_cleaning(llm_adapter, prompt: str, max_retries: int = 3) -> str:
             print("="*50 + "\n")
 
             # 清理结果中的特殊格式标记
-            result = result.replace("```", "").strip()
+            result = remove_think_tags(result).replace("```", "").strip()
             if result:
                 return result
             retry_count += 1

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import io
+from pathlib import Path
+import unittest
+from contextlib import redirect_stdout
+
+COMMON_PATH = Path(__file__).resolve().parents[1] / "novel_generator" / "common.py"
+SPEC = importlib.util.spec_from_file_location("common_under_test", COMMON_PATH)
+common = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(common)
+
+invoke_with_cleaning = common.invoke_with_cleaning
+remove_think_tags = common.remove_think_tags
+
+
+class FakeLLMAdapter:
+    def __init__(self, response):
+        self.response = response
+
+    def invoke(self, prompt):
+        return self.response
+
+
+class CommonCleaningTest(unittest.TestCase):
+    def test_remove_think_tags_strips_reasoning_blocks(self):
+        text = "prefix<think>internal reasoning</think>body"
+
+        self.assertEqual("prefixbody", remove_think_tags(text))
+
+    def test_invoke_with_cleaning_removes_think_tags_from_llm_output(self):
+        adapter = FakeLLMAdapter(
+            "```<think>internal reasoning should be hidden</think>\nChapter text```"
+        )
+
+        with redirect_stdout(io.StringIO()):
+            result = invoke_with_cleaning(adapter, "write chapter")
+
+        self.assertEqual("Chapter text", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Wire the existing `remove_think_tags()` helper into `invoke_with_cleaning()` so LLM responses no longer preserve `<think>...</think>` reasoning blocks.
- Add unit coverage for direct tag stripping and the full LLM cleaning path.

## Why

MiniMax and similar reasoning models can return hidden reasoning inside `<think>` tags. The helper existed, but the shared LLM invocation path did not call it, so those blocks could leak into generated novel output.

Fixes #215.

## Validation

- `python -m unittest tests.test_common`
- `python -m unittest discover -s tests`