### PR TITLE
清理直接 LLM 调用路径中的思考标签

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -7,6 +7,8 @@ import tempfile
 import threading
 from copy import deepcopy
 
+from llm_output_cleaning import remove_think_tags
+
 IS_ENGLISH = False
 _config_lock = threading.RLock()
 
@@ -278,6 +280,8 @@ def test_llm_config(interface_format, api_key, base_url, model_name, temperature
 
             test_prompt = "Please reply 'OK'"
             response = llm_adapter.invoke(test_prompt)
+            if response:
+                response = remove_think_tags(response).strip()
             if response:
                 log_func("✅ LLM配置测试成功！")
                 log_func(f"测试回复: {response}")

--- a/consistency_checker.py
+++ b/consistency_checker.py
@@ -1,6 +1,7 @@
 # consistency_checker.py
 # -*- coding: utf-8 -*-
 from llm_adapters import create_llm_adapter
+from llm_output_cleaning import remove_think_tags
 from novel_generator.common import log_llm_io
 
 # ============== 增加对“剧情要点/未解决冲突”进行检查的可选引导 ==============
@@ -65,7 +66,11 @@ def check_consistency(
     response = llm_adapter.invoke(prompt)
     if not response:
         return "审校Agent无回复"
-    
+
+    response = remove_think_tags(response).strip()
+    if not response:
+        return "审校Agent无回复"
+
     log_llm_io("ConsistencyChecker Response", response)
 
     return response

--- a/llm_output_cleaning.py
+++ b/llm_output_cleaning.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""轻量 LLM 输出清理工具。"""
+import re
+
+
+def remove_think_tags(text: str) -> str:
+    """移除 <think>...</think> 包裹的内容。"""
+    return re.sub(r'<think>.*?</think>', '', text, flags=re.DOTALL)

--- a/novel_generator/common.py
+++ b/novel_generator/common.py
@@ -5,9 +5,10 @@
 """
 import logging
 import os
-import re
 import time
 import traceback
+
+from llm_output_cleaning import remove_think_tags
 logging.basicConfig(
     filename='app.log',      # 日志文件名
     filemode='a',            # 追加模式（'w' 会覆盖）
@@ -36,10 +37,6 @@ def call_with_retry(func, max_retries=3, sleep_time=2, fallback_return=None, **k
             else:
                 logging.error("Max retries reached, returning fallback_return.")
                 return fallback_return
-
-def remove_think_tags(text: str) -> str:
-    """移除 <think>...</think> 包裹的内容"""
-    return re.sub(r'<think>.*?</think>', '', text, flags=re.DOTALL)
 
 def is_llm_io_debug_enabled() -> bool:
     return os.getenv("AI_NOVEL_DEBUG_LLM_IO", "").strip().lower() in {"1", "true", "yes", "on"}

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -28,6 +28,11 @@ class CommonCleaningTest(unittest.TestCase):
 
         self.assertEqual("prefixbody", remove_think_tags(text))
 
+    def test_remove_think_tags_strips_multiline_and_multiple_blocks(self):
+        text = "A<think>line 1\nline 2</think>B<think>another</think>C"
+
+        self.assertEqual("ABC", remove_think_tags(text))
+
     def test_invoke_with_cleaning_removes_think_tags_from_llm_output(self):
         adapter = FakeLLMAdapter(
             "```<think>internal reasoning should be hidden</think>\nChapter text```"

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,11 +1,23 @@
 import json
 import pathlib
+import sys
+import types
 import unittest
+from unittest import mock
 
+import config_manager
 from config_manager import get_default_config, normalize_config, validate_choose_configs
 
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class ImmediateThread:
+    def __init__(self, target, daemon=False):
+        self.target = target
+
+    def start(self):
+        self.target()
 
 
 class ConfigManagerTest(unittest.TestCase):
@@ -62,6 +74,39 @@ class ConfigManagerTest(unittest.TestCase):
 
         self.assertIn('emb_interface_options = ["OpenAI", "Azure OpenAI", "Gemini", "Ollama", "ML Studio", "SiliconFlow"]', config_tab_source)
         self.assertNotIn('emb_interface_options = ["DeepSeek"', config_tab_source)
+
+    def test_llm_config_test_cleans_think_tags_from_visible_reply(self):
+        class FakeAdapter:
+            def invoke(self, prompt):
+                return "<think>internal reasoning</think>OK"
+
+        fake_llm_adapters = types.ModuleType("llm_adapters")
+        fake_llm_adapters.create_llm_adapter = lambda **kwargs: FakeAdapter()
+        logs = []
+        errors = []
+
+        with (
+            mock.patch.dict(sys.modules, {"llm_adapters": fake_llm_adapters}),
+            mock.patch.object(config_manager.threading, "Thread", ImmediateThread),
+        ):
+            config_manager.test_llm_config(
+                interface_format="OpenAI",
+                api_key="key",
+                base_url="https://example.com",
+                model_name="model",
+                temperature=0.7,
+                max_tokens=100,
+                timeout=30,
+                log_func=logs.append,
+                handle_exception_func=errors.append,
+            )
+
+        visible_log = "\n".join(logs)
+        self.assertIn("测试回复: OK", visible_log)
+        self.assertNotIn("<think>", visible_log)
+        self.assertNotIn("</think>", visible_log)
+        self.assertNotIn("internal reasoning", visible_log)
+        self.assertEqual(errors, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_consistency_checker.py
+++ b/tests/test_consistency_checker.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONSISTENCY_CHECKER_PATH = REPO_ROOT / "consistency_checker.py"
+
+
+def load_consistency_checker(response):
+    class FakeAdapter:
+        def invoke(self, prompt):
+            return response
+
+    fake_llm_adapters = types.ModuleType("llm_adapters")
+    fake_llm_adapters.create_llm_adapter = lambda **kwargs: FakeAdapter()
+
+    log_records = []
+    fake_common = types.ModuleType("novel_generator.common")
+    fake_common.log_llm_io = lambda label, content: log_records.append((label, content))
+
+    fake_package = types.ModuleType("novel_generator")
+    fake_package.__path__ = []
+
+    spec = importlib.util.spec_from_file_location("consistency_checker_under_test", CONSISTENCY_CHECKER_PATH)
+    module = importlib.util.module_from_spec(spec)
+
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "llm_adapters": fake_llm_adapters,
+            "novel_generator": fake_package,
+            "novel_generator.common": fake_common,
+        },
+    ):
+        spec.loader.exec_module(module)
+
+    return module, log_records
+
+
+class ConsistencyCheckerTest(unittest.TestCase):
+    def test_check_consistency_cleans_think_tags_from_direct_llm_response(self):
+        module, log_records = load_consistency_checker("<think>secret reasoning</think>无明显冲突")
+
+        result = module.check_consistency(
+            novel_setting="设定",
+            character_state="角色",
+            global_summary="摘要",
+            chapter_text="章节",
+            api_key="key",
+            base_url="https://example.com",
+            model_name="model",
+        )
+
+        self.assertEqual(result, "无明显冲突")
+        self.assertNotIn("<think>", result)
+        self.assertNotIn("</think>", result)
+        self.assertNotIn("secret reasoning", result)
+        self.assertIn(("ConsistencyChecker Response", "无明显冲突"), log_records)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 新增无副作用的轻量 LLM 输出清理 helper，并保留 `novel_generator.common.remove_think_tags` 入口。
- 清理 `consistency_checker` 直接 LLM 返回中的 `<think>...</think>` 内容后再记录和返回。
- 清理 LLM 配置测试回复中的 `<think>...</think>` 内容后再显示到 UI 日志。
- 增加直接调用路径的回归测试。

## Test Plan
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -v`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m compileall main.py config_manager.py llm_adapters.py embedding_adapters.py consistency_checker.py utils.py chapter_directory_parser.py novel_generator ui tests`
- `git diff --check`

## Scope
- 本 PR 不修改 WebDAV 配置或日志逻辑。
- 本 PR 不改变 `invoke_with_cleaning` 的 retry、反引号清理或其他行为。